### PR TITLE
Add `grpc.WithKeepaliveParams` to dial options.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,12 @@ language: go
 
 env:
   global:
-    - BBLFSHD_VERSION=v2.12.1
-    - BBLFSH_PYTHON_VERSION=v2.9.0
     - GO111MODULE=on
 install:
   - |
     if [[ $TRAVIS_OS_NAME = linux ]]; then
-      docker run --privileged -d -p 9432:9432 --name bblfshd bblfsh/bblfshd:$BBLFSHD_VERSION
-      docker exec bblfshd bblfshctl driver install bblfsh/python-driver:$BBLFSH_PYTHON_VERSION
+      docker run --privileged -d -p 9432:9432 --name bblfshd bblfsh/bblfshd
+      docker exec bblfshd bblfshctl driver install bblfsh/python-driver
     fi
   - go mod download
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See `$ bblfsh-cli -h` for list of all available CLI options.
 ### Code
 This small example illustrates how to retrieve the [UAST](https://doc.bblf.sh/uast/specification.html) from a small Python script.
 
-If you don't have a bblfsh server installed, please read the [getting started](https://doc.bblf.sh/using-babelfish/getting-started.html) guide, to learn more about how to use and deploy a bblfsh server. 
+If you don't have a bblfsh server installed, please read the [getting started](https://doc.bblf.sh/using-babelfish/getting-started.html) guide, to learn more about how to use and deploy a bblfsh server.
 
 Go to the [quick start](https://github.com/bblfsh/bblfshd#quick-start) to discover how to run Babelfish with Docker.
 
@@ -32,17 +32,34 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/bblfsh/go-client/v4"
 	"github.com/bblfsh/go-client/v4/tools"
 
 	"github.com/bblfsh/sdk/v3/uast/nodes"
 	"github.com/bblfsh/sdk/v3/uast/uastyaml"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 )
 
 func main() {
-    	ctx := context.Background()
-	client, err := bblfsh.NewClientContext(ctx, "0.0.0.0:9432")
+	ctx := context.Background()
+	client, err := bblfsh.NewClientContext(ctx, "0.0.0.0:9432",
+		// Set an extra grpc DialOptions to avoid "transport closing" errors when client is idle.
+		// Passing keepalive params here, you can overwrite defaults:
+		// Time: 2 minutes, PermitWithoutStream: true
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			// Time is a duration after this if the client doesn't see any activity it
+			// pings the server to see if the transport is still alive.
+			Time:                2 * time.Minute,
+
+			// PermitWithoutStream is a boolean flag.
+			// If true, client sends keepalive pings even with no active RPCs.
+			PermitWithoutStream: true,
+		}),
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/client.go
+++ b/client.go
@@ -6,12 +6,26 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 
 	"github.com/bblfsh/sdk/v3/driver"
 	"github.com/bblfsh/sdk/v3/driver/manifest"
 	protocol2 "github.com/bblfsh/sdk/v3/protocol"
 	protocol1 "gopkg.in/bblfsh/sdk.v1/protocol"
+)
+
+const (
+	// defaultConnTimeout is a default connection timeout to bblfshd.
+	defaultConnTimeout = 5 * time.Second
+
+	// keepalivePingInterval is a duration after this if the client doesn't see any activity it
+	// pings the server to see if the transport is still alive.
+	keepalivePingInterval = 2 * time.Minute
+
+	// keepalivePingWithoutStream is a boolean flag.
+	// If true, client sends keepalive pings even with no active RPCs.
+	keepalivePingWithoutStream = true
 )
 
 // Client holds the public client API to interact with the bblfsh daemon.
@@ -26,6 +40,10 @@ func NewClientContext(ctx context.Context, endpoint string, options ...grpc.Dial
 	opts := []grpc.DialOption{
 		grpc.WithBlock(),
 		grpc.WithInsecure(),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                keepalivePingInterval,
+			PermitWithoutStream: keepalivePingWithoutStream,
+		}),
 	}
 	opts = append(opts, protocol2.DialOptions()...)
 	// user-defined options should go last
@@ -43,7 +61,7 @@ func NewClientContext(ctx context.Context, endpoint string, options ...grpc.Dial
 //
 // Deprecated: use NewClientContext instead
 func NewClient(endpoint string, options ...grpc.DialOption) (*Client, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultConnTimeout)
 	defer cancel()
 
 	return NewClientContext(ctx, endpoint, options...)
@@ -51,7 +69,7 @@ func NewClient(endpoint string, options ...grpc.DialOption) (*Client, error) {
 
 // NewClientWithConnection returns a new bblfsh client given a grpc connection.
 func NewClientWithConnection(conn *grpc.ClientConn) (*Client, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultConnTimeout)
 	defer cancel()
 
 	return NewClientWithConnectionContext(ctx, conn)

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	golang.org/x/net v0.0.0-20190520210107-018c4d40a106 // indirect
 	golang.org/x/sys v0.0.0-20190520201301-c432e742b0af // indirect
 	golang.org/x/text v0.3.2 // indirect
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190516172635-bb713bdc0e52 // indirect
 	google.golang.org/grpc v1.20.1
 	gopkg.in/bblfsh/sdk.v1 v1.17.0


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>
Addresses: https://github.com/bblfsh/go-client/issues/124

This PR sets and adds `grpc.WithKeepaliveParams` to `DialOptions`. Defaults are taken from: https://github.com/grpc/grpc-go/issues/2443#issuecomment-458507970
and exposed as public `bblfsh` package global variables, so any client can adjust them (if needed) before establish connection with `bblfshd`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/go-client/127)
<!-- Reviewable:end -->
